### PR TITLE
Added configuration to disable warning chat messages

### DIFF
--- a/Common/src/main/java/xaero/pac/common/server/claims/protection/ChunkProtection.java
+++ b/Common/src/main/java/xaero/pac/common/server/claims/protection/ChunkProtection.java
@@ -416,7 +416,7 @@ public class ChunkProtection
 	
 	private boolean onBlockAccess(IServerData<CM,P> serverData, BlockPos pos, Player player, Level world, InteractionHand hand, boolean emptyHand, boolean leftClick, boolean direct, Component message) {
 		if(blockAccessCheck(serverData, pos, player, null, world, emptyHand, leftClick)) {
-			if(direct) {
+			if(direct && !ServerConfig.CONFIG.hideMessageCantInteractBlock.get()) {
 				if(hand != null)
 					player.sendMessage(hand == InteractionHand.MAIN_HAND ? CANT_INTERACT_BLOCK_MAIN : CANT_INTERACT_BLOCK_OFF, player.getUUID());
 				if (message != null)
@@ -432,14 +432,18 @@ public class ChunkProtection
 			return false;
 		BlockState blockState = player.getLevel().getBlockState(pos);
 		if(completelyDisabledBlocks.contains(blockState.getBlock())){
-			player.sendMessage(BLOCK_DISABLED, player.getUUID());
+			if(!ServerConfig.CONFIG.hideMessageBlockDisabled.get())
+				player.sendMessage(BLOCK_DISABLED, player.getUUID());
 			return true;
 		}
 		if(CREATE_DEPLOYER_UUID.equals(player.getUUID()))//uses custom protection
 			return false;
 		ItemStack itemStack = player.getItemInHand(hand);
 		boolean emptyHand = itemStack.getItem() == Items.AIR;
-		Component message = emptyHand ? null : hand == InteractionHand.MAIN_HAND ? BLOCK_TRY_EMPTY_MAIN : BLOCK_TRY_EMPTY_OFF;
+
+		Component message = null;
+		if(!ServerConfig.CONFIG.hideMessageBlockTryEmpty.get())
+			message = emptyHand ? null : hand == InteractionHand.MAIN_HAND ? BLOCK_TRY_EMPTY_MAIN : BLOCK_TRY_EMPTY_OFF;
 		if(onBlockAccess(serverData, pos, player, player.getLevel(), hand, emptyHand, false, true, message))
 			return true;
 		return !emptyHand && onUseItemAt(serverData, player, pos, blockHit.getDirection(), itemStack, hand, true);
@@ -450,7 +454,8 @@ public class ChunkProtection
 			return false;
 		BlockState blockState = player.getLevel().getBlockState(pos);
 		if(completelyDisabledBlocks.contains(blockState.getBlock())){
-			player.sendMessage(BLOCK_DISABLED, player.getUUID());
+			if(!ServerConfig.CONFIG.hideMessageBlockDisabled.get())
+				player.sendMessage(BLOCK_DISABLED, player.getUUID());
 			return true;
 		}
 		if(CREATE_DEPLOYER_UUID.equals(player.getUUID()))//uses custom protection
@@ -512,7 +517,8 @@ public class ChunkProtection
 		boolean shouldProtect = false;
 		Item item = itemStack.getItem();
 		if(completelyDisabledItems.contains(item)) {
-			player.sendMessage(hand == InteractionHand.MAIN_HAND ? ITEM_DISABLED_MAIN : ITEM_DISABLED_OFF, player.getUUID());
+			if(!ServerConfig.CONFIG.hideMessageItemDisabled.get())
+				player.sendMessage(hand == InteractionHand.MAIN_HAND ? ITEM_DISABLED_MAIN : ITEM_DISABLED_OFF, player.getUUID());
 			return true;
 		}
 		if(isItemUseRestricted(itemStack) && !(item instanceof BucketItem) && !(item instanceof SolidBucketItem)) {
@@ -547,8 +553,10 @@ public class ChunkProtection
 					}
 				}
 		}
-		if(message && shouldProtect)
-			player.sendMessage(hand == InteractionHand.MAIN_HAND ? USE_ITEM_MAIN : USE_ITEM_OFF, player.getUUID());
+		if(message && shouldProtect){
+			if(!ServerConfig.CONFIG.hideMessageUseItem.get())
+				player.sendMessage(hand == InteractionHand.MAIN_HAND ? USE_ITEM_MAIN : USE_ITEM_OFF, player.getUUID());
+		}
 		return shouldProtect;
 	}
 
@@ -608,7 +616,7 @@ public class ChunkProtection
 		if(!ServerConfig.CONFIG.claimsEnabled.get())
 			return false;
 		if(!attack && completelyDisabledEntities.contains(target.getType())){
-			if(hand == InteractionHand.MAIN_HAND && entity instanceof Player player)
+			if(hand == InteractionHand.MAIN_HAND && entity instanceof Player player && !ServerConfig.CONFIG.hideMessageEntityDisabled.get())
 				player.sendMessage(ENTITY_DISABLED, player.getUUID());
 			return true;
 		}
@@ -640,10 +648,11 @@ public class ChunkProtection
 		) {
 			if(direct && entity instanceof Player) {
 				if(attack || posSpecific) {//avoiding double messages
-					entity.sendMessage(hand == InteractionHand.MAIN_HAND ? CANT_INTERACT_ENTITY_MAIN : CANT_INTERACT_ENTITY_OFF, entity.getUUID());
+					if(!ServerConfig.CONFIG.hideMessageCantInteractEntity.get())
+						entity.sendMessage(hand == InteractionHand.MAIN_HAND ? CANT_INTERACT_ENTITY_MAIN : CANT_INTERACT_ENTITY_OFF, entity.getUUID());
 					if (!attack && !emptyHand) {
-						Component message = hand == InteractionHand.MAIN_HAND ? ENTITY_TRY_EMPTY_MAIN : ENTITY_TRY_EMPTY_OFF;
-						entity.sendMessage(message, entity.getUUID());
+						if(!ServerConfig.CONFIG.hideMessageEntityTryEmpty.get())
+							entity.sendMessage(hand == InteractionHand.MAIN_HAND ? ENTITY_TRY_EMPTY_MAIN : ENTITY_TRY_EMPTY_OFF, entity.getUUID());
 					}
 				}
 			}
@@ -830,7 +839,7 @@ public class ChunkProtection
 			accessorId = accessor.getUUID();
 		}
 		if(checkProtectionLeveledOption(PlayerConfigOptions.PROTECT_CLAIMED_CHUNKS_CHORUS_FRUIT, claimConfig, accessor, accessorId) && !hasChunkAccess(claimConfig, accessor, accessorId)) {
-			if(entity instanceof Player)
+			if(entity instanceof Player && !ServerConfig.CONFIG.hideMessageCantChorus.get())
 				entity.sendMessage(CANT_CHORUS, entity.getUUID());
 			//OpenPartiesAndClaims.LOGGER.info("stopped {} from teleporting to {}", entity, pos);
 			return true;
@@ -918,7 +927,8 @@ public class ChunkProtection
 				hand = player.getItemInHand(InteractionHand.MAIN_HAND) == itemStack ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND;
 			if (additionalBannedItems.contains(itemStack.getItem()) &&
 					onItemRightClick(serverData, hand, itemStack, pos, player, false)) {//only configured items on purpose
-				player.sendMessage(hand == InteractionHand.MAIN_HAND ? CANT_APPLY_ITEM_THIS_CLOSE_MAIN : CANT_APPLY_ITEM_THIS_CLOSE_OFF, player.getUUID());
+				if(!ServerConfig.CONFIG.hideMessageCantApplyItemThisClose.get())
+					player.sendMessage(hand == InteractionHand.MAIN_HAND ? CANT_APPLY_ITEM_THIS_CLOSE_MAIN : CANT_APPLY_ITEM_THIS_CLOSE_OFF, player.getUUID());
 				return true;
 			}
 		}
@@ -930,8 +940,10 @@ public class ChunkProtection
 		if(applyItemAccessCheck(serverData, chunkPos = new ChunkPos(pos), entity, (ServerLevel) entity.getLevel(), itemStack)
 			|| pos2 != null && !(chunkPos2 = new ChunkPos(pos2)).equals(chunkPos) && applyItemAccessCheck(serverData, chunkPos2, entity, (ServerLevel) entity.getLevel(), itemStack)
 				){
-			if(message && entity instanceof ServerPlayer player)
-				player.sendMessage(hand == InteractionHand.MAIN_HAND ? CANT_APPLY_ITEM_MAIN : CANT_APPLY_ITEM_OFF, player.getUUID());
+			if(message && entity instanceof ServerPlayer player) {
+				if(!ServerConfig.CONFIG.hideMessageCantApplyItem.get())
+					player.sendMessage(hand == InteractionHand.MAIN_HAND ? CANT_APPLY_ITEM_MAIN : CANT_APPLY_ITEM_OFF, player.getUUID());
+			}
 			return true;
 		}
 		return false;

--- a/Common/src/main/java/xaero/pac/common/server/config/ServerConfig.java
+++ b/Common/src/main/java/xaero/pac/common/server/config/ServerConfig.java
@@ -75,6 +75,17 @@ public class ServerConfig {
 	public final ForgeConfigSpec.ConfigValue<String> maxPlayerClaimsFTBPermission;
 	public final ForgeConfigSpec.ConfigValue<String> maxPlayerClaimForceloadsFTBPermission;
 	public final ForgeConfigSpec.ConfigValue<String> serverClaimFTBPermission;
+	public final ForgeConfigSpec.BooleanValue hideMessageBlockDisabled;
+	public final ForgeConfigSpec.BooleanValue hideMessageCantInteractBlock;
+	public final ForgeConfigSpec.BooleanValue hideMessageBlockTryEmpty;
+	public final ForgeConfigSpec.BooleanValue hideMessageEntityDisabled;
+	public final ForgeConfigSpec.BooleanValue hideMessageCantInteractEntity;
+	public final ForgeConfigSpec.BooleanValue hideMessageEntityTryEmpty;
+	public final ForgeConfigSpec.BooleanValue hideMessageItemDisabled;
+	public final ForgeConfigSpec.BooleanValue hideMessageUseItem;
+	public final ForgeConfigSpec.BooleanValue hideMessageCantApplyItem;
+	public final ForgeConfigSpec.BooleanValue hideMessageCantApplyItemThisClose;
+	public final ForgeConfigSpec.BooleanValue hideMessageCantChorus;
 	public final ForgeConfigSpec.ConfigValue<String> adminModeFTBPermission;
 
 	private ServerConfig(ForgeConfigSpec.Builder builder) {
@@ -501,6 +512,72 @@ public class ServerConfig {
 				.translation("gui.xaero_pac_config_completely_disable_frost_walking")
 				.worldRestart()
 				.define("completelyDisableFrostWalking", false);
+
+		hideMessageBlockDisabled = builder
+				.comment("Whether to send a warning message when the client tries to interact with a disabled block.")
+				.translation("gui.xaero_pac_config_hide_message_block_disabled")
+				.worldRestart()
+				.define("hideMessageBlockDisabled", false);
+
+		hideMessageCantInteractBlock = builder
+			.comment("Whether to send a warning message to the client when not allowed to interact with a block.")
+			.translation("gui.xaero_pac_config_completely_hide_message_cant_interact_block")
+			.worldRestart()
+			.define("hideMessageCantInteractBlock", false);
+
+		hideMessageBlockTryEmpty = builder
+			.comment("Whether to send a warning message to the client suggesting trying to interact on a block empty-handed.")
+			.translation("gui.xaero_pac_config_hide_message_block_try_empty")
+			.worldRestart()
+			.define("hideMessageBlockTryEmpty", false);
+
+		hideMessageEntityDisabled = builder
+				.comment("Whether to send a warning message when the client tries to interact with a disabled entity.")
+				.translation("gui.xaero_pac_config_hide_message_entity_disabled")
+				.worldRestart()
+				.define("hideMessageEntityDisabled", false);
+
+		hideMessageCantInteractEntity = builder
+			.comment("Whether to send a warning message when the client is not allowed to interact with an entity.")
+			.translation("gui.xaero_pac_config_hide_message_cant_interact_entity")
+			.worldRestart()
+			.define("hideMessageCantInteractEntity", false);
+
+		hideMessageEntityTryEmpty = builder
+			.comment("Whether to send a warning message to the client suggesting trying to interact on the entity empty-handed.")
+			.translation("gui.xaero_pac_config_hide_message_entity_try_empty")
+			.worldRestart()
+			.define("hideMessageEntityTryEmpty", false);
+
+		hideMessageItemDisabled = builder
+			.comment("Whether to send a warning message to the client when trying to use a disabled item.")
+			.translation("gui.xaero_pac_config_hide_message_item_disabled")
+			.worldRestart()
+			.define("hideMessageItemDisabled", false);
+
+		hideMessageUseItem = builder
+				.comment("Whether to send a warning message to the client when trying to use an item close to someone else's claim.")
+				.translation("gui.xaero_pac_config_hide_message_use_item")
+				.worldRestart()
+				.define("hideMessageUseItem", false);
+
+		hideMessageCantApplyItem = builder
+			.comment("Whether to send a warning message when the client is not allowed to apply an item at this position.")
+			.translation("gui.xaero_pac_config_hide_message_cant_apply_item")
+			.worldRestart()
+			.define("hideMessageCantApplyItem", false);
+
+		hideMessageCantApplyItemThisClose = builder
+			.comment("Whether to send a warning message to the client when trying to apply an item close to someone else's claim.")
+			.translation("gui.xaero_pac_config_hide_message_cant_apply_item_this_close")
+			.worldRestart()
+			.define("hideMessageCantApplyItemThisClose", false);
+
+		hideMessageCantChorus = builder
+				.comment("Whether to send a warning message to the client when not allowed to eat a chorus fruit.")
+				.translation("gui.xaero_pac_config_hide_message_cant_chorus")
+				.worldRestart()
+				.define("hideMessageCantChorus", false);
 
 		builder.pop();
 

--- a/Common/src/main/java/xaero/pac/common/server/config/ServerConfig.java
+++ b/Common/src/main/java/xaero/pac/common/server/config/ServerConfig.java
@@ -75,6 +75,17 @@ public class ServerConfig {
 	public final ForgeConfigSpec.ConfigValue<String> maxPlayerClaimsFTBPermission;
 	public final ForgeConfigSpec.ConfigValue<String> maxPlayerClaimForceloadsFTBPermission;
 	public final ForgeConfigSpec.ConfigValue<String> serverClaimFTBPermission;
+	public final ForgeConfigSpec.BooleanValue hideMessageBlockDisabled;
+	public final ForgeConfigSpec.BooleanValue hideMessageCantInteractBlock;
+	public final ForgeConfigSpec.BooleanValue hideMessageBlockTryEmpty;
+	public final ForgeConfigSpec.BooleanValue hideMessageEntityDisabled;
+	public final ForgeConfigSpec.BooleanValue hideMessageCantInteractEntity;
+	public final ForgeConfigSpec.BooleanValue hideMessageEntityTryEmpty;
+	public final ForgeConfigSpec.BooleanValue hideMessageItemDisabled;
+	public final ForgeConfigSpec.BooleanValue hideMessageUseItem;
+	public final ForgeConfigSpec.BooleanValue hideMessageCantApplyItem;
+	public final ForgeConfigSpec.BooleanValue hideMessageCantApplyItemThisClose;
+	public final ForgeConfigSpec.BooleanValue hideMessageCantChorus;
 
 	private ServerConfig(ForgeConfigSpec.Builder builder) {
 		builder.push("serverConfig");
@@ -494,6 +505,72 @@ public class ServerConfig {
 				.translation("gui.xaero_pac_config_completely_disable_frost_walking")
 				.worldRestart()
 				.define("completelyDisableFrostWalking", false);
+
+		hideMessageBlockDisabled = builder
+				.comment("Whether to send a warning message when the client tries to interact with a disabled block.")
+				.translation("gui.xaero_pac_config_hide_message_block_disabled")
+				.worldRestart()
+				.define("hideMessageBlockDisabled", false);
+
+		hideMessageCantInteractBlock = builder
+			.comment("Whether to send a warning message to the client when not allowed to interact with a block.")
+			.translation("gui.xaero_pac_config_completely_hide_message_cant_interact_block")
+			.worldRestart()
+			.define("hideMessageCantInteractBlock", false);
+
+		hideMessageBlockTryEmpty = builder
+			.comment("Whether to send a warning message to the client suggesting trying to interact on a block empty-handed.")
+			.translation("gui.xaero_pac_config_hide_message_block_try_empty")
+			.worldRestart()
+			.define("hideMessageBlockTryEmpty", false);
+
+		hideMessageEntityDisabled = builder
+				.comment("Whether to send a warning message when the client tries to interact with a disabled entity.")
+				.translation("gui.xaero_pac_config_hide_message_entity_disabled")
+				.worldRestart()
+				.define("hideMessageEntityDisabled", false);
+
+		hideMessageCantInteractEntity = builder
+			.comment("Whether to send a warning message when the client is not allowed to interact with an entity.")
+			.translation("gui.xaero_pac_config_hide_message_cant_interact_entity")
+			.worldRestart()
+			.define("hideMessageCantInteractEntity", false);
+
+		hideMessageEntityTryEmpty = builder
+			.comment("Whether to send a warning message to the client suggesting trying to interact on the entity empty-handed.")
+			.translation("gui.xaero_pac_config_hide_message_entity_try_empty")
+			.worldRestart()
+			.define("hideMessageEntityTryEmpty", false);
+
+		hideMessageItemDisabled = builder
+			.comment("Whether to send a warning message to the client when trying to use a disabled item.")
+			.translation("gui.xaero_pac_config_hide_message_item_disabled")
+			.worldRestart()
+			.define("hideMessageItemDisabled", false);
+
+		hideMessageUseItem = builder
+				.comment("Whether to send a warning message to the client when trying to use an item close to someone else's claim.")
+				.translation("gui.xaero_pac_config_hide_message_use_item")
+				.worldRestart()
+				.define("hideMessageUseItem", false);
+
+		hideMessageCantApplyItem = builder
+			.comment("Whether to send a warning message when the client is not allowed to apply an item at this position.")
+			.translation("gui.xaero_pac_config_hide_message_cant_apply_item")
+			.worldRestart()
+			.define("hideMessageCantApplyItem", false);
+
+		hideMessageCantApplyItemThisClose = builder
+			.comment("Whether to send a warning message to the client when trying to apply an item close to someone else's claim.")
+			.translation("gui.xaero_pac_config_hide_message_cant_apply_item_this_close")
+			.worldRestart()
+			.define("hideMessageCantApplyItemThisClose", false);
+
+		hideMessageCantChorus = builder
+				.comment("Whether to send a warning message to the client when not allowed to eat a chorus fruit.")
+				.translation("gui.xaero_pac_config_hide_message_cant_chorus")
+				.worldRestart()
+				.define("hideMessageCantChorus", false);
 
 		builder.pop();
 

--- a/Common/src/main/java/xaero/pac/common/server/config/ServerConfig.java
+++ b/Common/src/main/java/xaero/pac/common/server/config/ServerConfig.java
@@ -508,16 +508,16 @@ public class ServerConfig {
 			.defineListAllowEmpty(Lists.newArrayList("completelyDisabledEntityInteractions"), Lists::newArrayList, s -> s instanceof String);
 
 		completelyDisableFrostWalking = builder
-				.comment("Whether to completely disable frost walking on the server. Use this if the regular frost walking protection doesn't work, since there is no game rule for it.")
-				.translation("gui.xaero_pac_config_completely_disable_frost_walking")
-				.worldRestart()
-				.define("completelyDisableFrostWalking", false);
+			.comment("Whether to completely disable frost walking on the server. Use this if the regular frost walking protection doesn't work, since there is no game rule for it.")
+			.translation("gui.xaero_pac_config_completely_disable_frost_walking")
+			.worldRestart()
+			.define("completelyDisableFrostWalking", false);
 
 		hideMessageBlockDisabled = builder
-				.comment("Whether to send a warning message when the client tries to interact with a disabled block.")
-				.translation("gui.xaero_pac_config_hide_message_block_disabled")
-				.worldRestart()
-				.define("hideMessageBlockDisabled", false);
+			.comment("Whether to send a warning message when the client tries to interact with a disabled block.")
+			.translation("gui.xaero_pac_config_hide_message_block_disabled")
+			.worldRestart()
+			.define("hideMessageBlockDisabled", false);
 
 		hideMessageCantInteractBlock = builder
 			.comment("Whether to send a warning message to the client when not allowed to interact with a block.")
@@ -532,10 +532,10 @@ public class ServerConfig {
 			.define("hideMessageBlockTryEmpty", false);
 
 		hideMessageEntityDisabled = builder
-				.comment("Whether to send a warning message when the client tries to interact with a disabled entity.")
-				.translation("gui.xaero_pac_config_hide_message_entity_disabled")
-				.worldRestart()
-				.define("hideMessageEntityDisabled", false);
+			.comment("Whether to send a warning message when the client tries to interact with a disabled entity.")
+			.translation("gui.xaero_pac_config_hide_message_entity_disabled")
+			.worldRestart()
+			.define("hideMessageEntityDisabled", false);
 
 		hideMessageCantInteractEntity = builder
 			.comment("Whether to send a warning message when the client is not allowed to interact with an entity.")
@@ -556,10 +556,10 @@ public class ServerConfig {
 			.define("hideMessageItemDisabled", false);
 
 		hideMessageUseItem = builder
-				.comment("Whether to send a warning message to the client when trying to use an item close to someone else's claim.")
-				.translation("gui.xaero_pac_config_hide_message_use_item")
-				.worldRestart()
-				.define("hideMessageUseItem", false);
+			.comment("Whether to send a warning message to the client when trying to use an item close to someone else's claim.")
+			.translation("gui.xaero_pac_config_hide_message_use_item")
+			.worldRestart()
+			.define("hideMessageUseItem", false);
 
 		hideMessageCantApplyItem = builder
 			.comment("Whether to send a warning message when the client is not allowed to apply an item at this position.")
@@ -574,10 +574,10 @@ public class ServerConfig {
 			.define("hideMessageCantApplyItemThisClose", false);
 
 		hideMessageCantChorus = builder
-				.comment("Whether to send a warning message to the client when not allowed to eat a chorus fruit.")
-				.translation("gui.xaero_pac_config_hide_message_cant_chorus")
-				.worldRestart()
-				.define("hideMessageCantChorus", false);
+			.comment("Whether to send a warning message to the client when not allowed to eat a chorus fruit.")
+			.translation("gui.xaero_pac_config_hide_message_cant_chorus")
+			.worldRestart()
+			.define("hideMessageCantChorus", false);
 
 		builder.pop();
 


### PR DESCRIPTION
I find these messages very useful when you discover this mod and want to try items to know which one you need to whitelist.
But when it's done, it is a bit frustrating to see your chat spammed with red messages.

So I added configuration booleans for each type of message and implemented a check before sending any warning message.