### PR TITLE
fabric: fix boat chest crash

### DIFF
--- a/Fabric/src/main/java/xaero/pac/common/mixin/MixinAbstractBoat.java
+++ b/Fabric/src/main/java/xaero/pac/common/mixin/MixinAbstractBoat.java
@@ -33,7 +33,7 @@ public class MixinAbstractBoat {
 
 	@ModifyVariable(method = "tick", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/level/Level;getEntities(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;"))
 	public List<Entity> onTickGetEntities(List<Entity> list){
-		ServerCore.onEntityAffectsEntities(list, (Boat)(Object)this);
+		ServerCore.onEntityAffectsEntities(list, (AbstractBoat)(Object)this);
 		return list;
 	}
 


### PR DESCRIPTION
The inheritance structure changed. Currently, a player loading any boat chest causes the server to crash.