### PR TITLE
Fix Create-compat crash on neoforge 26.2.0.59+ (AbstractMinecart package move, removed EntityInteractSpecific)

### DIFF
--- a/CreateSupportCommon/src/main/java/xaero/pac/common/mixin/create/MixinMinecartContraptionItem.java
+++ b/CreateSupportCommon/src/main/java/xaero/pac/common/mixin/create/MixinMinecartContraptionItem.java
@@ -29,12 +29,12 @@ import xaero.pac.common.server.core.ServerCore;
 @Mixin(MinecartContraptionItem.class)
 public class MixinMinecartContraptionItem {
 
-	@Inject(method = "useOn", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/contraptions/mounted/MinecartContraptionItem;addContraptionToMinecart(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/vehicle/AbstractMinecart;Lnet/minecraft/core/Direction;)V"))
+	@Inject(method = "useOn", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/contraptions/mounted/MinecartContraptionItem;addContraptionToMinecart(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/vehicle/minecart/AbstractMinecart;Lnet/minecraft/core/Direction;)V"))
 	public void onUseOnPre(UseOnContext context, CallbackInfoReturnable<Boolean> cir){
 		ServerCore.preMinecartContraptionPlaced(context);
 	}
 
-	@Inject(method = "useOn", at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lcom/simibubi/create/content/contraptions/mounted/MinecartContraptionItem;addContraptionToMinecart(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/vehicle/AbstractMinecart;Lnet/minecraft/core/Direction;)V"))
+	@Inject(method = "useOn", at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lcom/simibubi/create/content/contraptions/mounted/MinecartContraptionItem;addContraptionToMinecart(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/vehicle/minecart/AbstractMinecart;Lnet/minecraft/core/Direction;)V"))
 	public void onUseOnPost(UseOnContext context, CallbackInfoReturnable<Boolean> cir){
 		ServerCore.postMinecartContraptionPlaced();
 	}

--- a/NeoForge/src/main/java/xaero/pac/common/event/CommonEventsNeoForge.java
+++ b/NeoForge/src/main/java/xaero/pac/common/event/CommonEventsNeoForge.java
@@ -232,12 +232,6 @@ public class CommonEventsNeoForge extends CommonEvents {
 			event.setCanceled(true);
 	}
 
-	@SubscribeEvent(priority = EventPriority.HIGHEST)
-	public void onInteractEntitySpecific(PlayerInteractEvent.EntityInteractSpecific event) {
-		if(super.onInteractEntitySpecific(event.getEntity(), event.getTarget(), event.getHand()))
-			event.setCanceled(true);
-	}
-	
 	@SubscribeEvent
 	public void onExplosionDetonate(ExplosionEvent.Detonate event) {
 		super.onExplosionDetonate(event.getLevel(), event.getExplosion(), event.getAffectedEntities(), event.getAffectedBlocks());


### PR DESCRIPTION
## Summary
Two stale references against real Minecraft/NeoForge API moves in the 26.2 line currently crash this mod's Create integration entirely - and take down Create's own mod construction, not just this mod's optional Create feature.

1. `net.minecraft.world.entity.vehicle.AbstractMinecart` moved to `net.minecraft.world.entity.vehicle.minecart.AbstractMinecart`. `MixinMinecartContraptionItem`'s `@At(INVOKE)` descriptors still pointed at the old package, so Mixin's bytecode scanner finds zero matching instructions ("Scanned 0 target(s)") when applying to Create's `MinecartContraptionItem.useOn`. Since this mixin applies during Create's own `AllItems`/`AllBlocks` class-init, the injection failure crashes Create's mod construction outright.

2. `PlayerInteractEvent.EntityInteractSpecific` no longer exists - it was merged into `EntityInteract`, which now carries the `Vec3 location` field the `Specific` variant used to carry separately. `CommonEventsNeoForge.onInteractEntitySpecific` subscribes to the now-nonexistent event class, throwing `NoClassDefFoundError` during `FMLCommonSetupEvent` and crashing this mod's own construction.

This repo's `gradle.properties` pins `neoforge_version=26.2.0.6-beta`, an earlier 26.2 beta where `EntityInteractSpecific` still existed - which is why the current 0.30.1 release compiles cleanly but crashes at runtime against later 26.2.0.x builds (I hit this against 26.2.0.59).

## Changes
- `MixinMinecartContraptionItem`: update both `@At(INVOKE)` target descriptors to the new `AbstractMinecart` package.
- `CommonEventsNeoForge`: delete the dead `onInteractEntitySpecific` handler; `onEntityInteract` alone now covers this (it already receives the location data via the merged event).

## Testing
Verified via a full dedicated-server boot test with Create present: both crashes are gone, server reaches a clean `Done!` with no further errors from either mod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)